### PR TITLE
Removed quotes so it will be interpreted by OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eslint:node": "eslint --fix --ignore-pattern *.test.js --ignore-pattern server/test lib server",
     "eslint:test": "eslint --fix --config=.eslintrc.test.json  **/*.test.js",
     "eslint": "npm run -s eslint:node && npm run -s eslint:test",
-    "test:unit": "mocha 'lib/**/*.unit.test.js'",
+    "test:unit": "mocha lib/**/*.unit.test.js",
     "test": "npm run test:unit",
     "coverage:unit": "nyc --report-dir=coverage/unit npm run test:unit",
     "coverage": "npm run coverage:unit"


### PR DESCRIPTION
These quotes were causing the issue for Windows to not find the files. Removing them is working in our Windows setup.