### PR TITLE
Allow model to retrieve overview info

### DIFF
--- a/lib/headstart.js
+++ b/lib/headstart.js
@@ -58,7 +58,6 @@ class HeadStart {
         this.domains = this.domains.filter((d) => d.name !== domainName);
     }
 
-
     toString() {
         return this.domains.map((domain) => domain.toString()).join('\n') + '\n';
     }

--- a/lib/models/entity-overview.js
+++ b/lib/models/entity-overview.js
@@ -1,0 +1,58 @@
+const _ = require('lodash');
+const Promise = require('bluebird');
+
+function initResultObject(docEntity, doc) {
+    return docEntity.getBasicProperties().reduce(
+        (memo, basicProperty) => _.extend(memo, {
+            [basicProperty.name]: doc[basicProperty.name]
+        }),
+        {
+            type: doc.type,
+            id: doc.id
+        }
+    );
+}
+
+function extractInfo(persistence, docEntity, recursiveCount, doc) {
+    return Promise.resolve()
+        .then(() => {
+            const resultObject = initResultObject(docEntity, doc);
+
+            if (!recursiveCount) {
+                return resultObject;
+            }
+
+            return Promise.reduce(
+                docEntity.getRelationships(),
+                (memo, relationship) => {
+                    return relationship.getDocuments(persistence, doc)
+                        .then((targetDocs) => {
+                            return Promise.map(
+                                    targetDocs,
+                                    (targetDoc) => {
+                                        return extractInfo(persistence, relationship.getTargetEntity(), recursiveCount - 1, targetDoc);
+                                    }
+                                )
+                                .then((infos) => {
+                                    return _.extend(memo, {
+                                        [relationship.name]: infos
+                                    });
+                                });
+                        });
+                },
+                resultObject
+            );
+        });
+}
+
+module.exports = (persistence, instance, overviewRelationship) => {
+    // Recursion level:
+    //  1: Image
+    //  2: Map
+    //  3: Target
+    const extractParagraphInfo = extractInfo.bind(null, persistence, overviewRelationship.getTargetEntity(), 3);
+
+    return overviewRelationship.getDocuments(persistence, instance)
+        .then((docs) => docs[0])
+        .then(extractParagraphInfo);
+};

--- a/lib/models/entity.js
+++ b/lib/models/entity.js
@@ -1,5 +1,8 @@
+const Promise = require('bluebird');
+
 const Base = require('./base');
 const BasicProperty = require('./basic-property');
+const entityOverview = require('./entity-overview');
 const Enumeration = require('./enumeration');
 const Relationship = require('./relationship');
 const utils = require('./../utils');
@@ -129,6 +132,13 @@ class Entity extends Base {
                 }
             }
         }
+    }
+
+    getOverview(persistence, instance) {
+        return Promise.resolve()
+            .then(() => this.getRelationships())
+            .then((relationships) => relationships.find((relationship) => relationship.name === 'Overview'))
+            .then(entityOverview.bind(null, persistence, instance));
     }
 
     createNewDefaultPageView() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "HeadStart",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/dslama/HeadStart.git"
@@ -32,18 +32,18 @@
   "dependencies": {
     "bluebird": "3.5.0",
     "lodash": "4.17.4",
-    "mongodb": "2.2.24",
+    "mongodb": "2.2.25",
     "rc": "1.1.7"
   },
   "devDependencies": {
-    "body-parser": "1.17.0",
+    "body-parser": "1.17.1",
     "cookie-parser": "1.4.3",
-    "debug": "2.6.1",
-    "eslint": "3.17.0",
-    "eslint-config-standard": "7.0.0",
+    "debug": "2.6.3",
+    "eslint": "3.17.1",
+    "eslint-config-standard": "7.0.1",
     "eslint-plugin-promise": "3.5.0",
     "eslint-plugin-standard": "2.1.1",
-    "express": "4.15.0",
+    "express": "4.15.2",
     "hbs": "4.0.1",
     "hbs-utils": "0.0.4",
     "mocha": "3.2.0",


### PR DESCRIPTION
Delegate the overview information to the entity model instead of doing it in the implementation code.