### PR TITLE
Disable domain caching because 2 servers.

### DIFF
--- a/lib/headstart.js
+++ b/lib/headstart.js
@@ -37,19 +37,19 @@ class HeadStart {
     }
 
     getDomainByName(domainName) {
-        let domain = this.domains.find((domain) => domain.name === domainName);
-        if (domain) {
-            return domain;
-        }
+        // let domain = this.domains.find((domain) => domain.name === domainName);
+        // if (domain) {
+        //     return domain;
+        // }
 
         const domainFilePath = path.resolve(this.getDir('domains', `${domainName}.jsn`));
 
         const content = this.readFile(domainFilePath);
         const domainJson = JSON.parse(content);
 
-        domain = this.createDomainFromJSON(domainJson);
+        const domain = this.createDomainFromJSON(domainJson);
 
-        this.domains.push(domain);
+        // this.domains.push(domain);
 
         return domain;
     }


### PR DESCRIPTION
Because the HeadStart is a tool that runs on a different port than the portal server (2 different processes), it's not possible to update the portal server's cache when something changes in HeadStart. By disabling the caching, the `domain.jsn` file is read and parsed at each request, but it assure that we always have the latest schema.

This is a temporary solution.